### PR TITLE
Fix PHP errors on admin page with empty options

### DIFF
--- a/classes/class-pbs-media-manager-settings.php
+++ b/classes/class-pbs-media-manager-settings.php
@@ -90,9 +90,9 @@ ID as used by PBS to identify the station. Visit https://station.services.pbs.or
     $field = esc_attr( $args['field'] );
     $label = esc_attr( $args['label'] );
     $class = esc_attr( $args['class'] );
-    $type = ($args['type'] ? esc_attr( $args['type'] ) : 'text' );
-    $options = (is_array($args['options']) ? $args['options'] : array('true', 'false') );
-    $default = ($args['default'] ? esc_attr( $args['default'] ) : '' );
+    $type = ( isset($args['type']) ? esc_attr( $args['type'] ) : 'text' );
+    $options = ( isset($args['options']) && is_array($args['options']) ? $args['options'] : array('true', 'false') );
+    $default = ( isset($args['default']) ? esc_attr( $args['default'] ) : '' );
     switch ($type) {
       case "checkbox":
         // dont set a default for checkboxes


### PR DESCRIPTION
Was getting `Undefined index:` error on the admin page
when the fields are empty. So just after installing the plugin.
Adjusting how the conditionals are being checked fixes it.

Finally getting around to experimenting with the API and trying out the WordPress plugin today. :smile: 